### PR TITLE
Change 2^32 to Math.pow(2,32)

### DIFF
--- a/Chapter07/03.scala
+++ b/Chapter07/03.scala
@@ -5,7 +5,7 @@ package object random {
 
 	def setSeed(value: Int) = seed = value
 	def nextInt() = {
-		seed = seed * 1664525 + 1013904223 % (2 ^ 32)
+		seed = seed * 1664525 + 1013904223 % Math.pow(2, 32).toInt
 		seed
 	}
 	def nextDouble() : Double = nextInt().toDouble / Int.MaxValue.toDouble


### PR DESCRIPTION
The ^ operator is the bitwise XOR of the value, instead Math.pow() raises 2 to 32.

You could also use 1.toLong << 32 to get the same effect.
