### PR TITLE
Update Chapter07/06.scala

### DIFF
--- a/Chapter07/06.scala
+++ b/Chapter07/06.scala
@@ -1,17 +1,14 @@
 import java.util.{HashMap => JavaHashMap, Map => JavaMap}
 import collection.mutable.{HashMap => ScalaHashMap, Map => ScalaMap}
-import collection.JavaConversions.mapAsScalaMap
+import collection.JavaConverters._
 
-val j: ScalaMap[Int, String] = new java.util.HashMap[Int,String]
+val j: JavaMap[Int, String] = new JavaHashMap[Int, String]
 
-j.put(1, "One");
-j.put(2, "Two");
+j.put(1, "One")
+j.put(2, "Two")
 
-val s: ScalaMap[Int, String] = new ScalaHashMap();
+val s: ScalaMap[Int, String] = new ScalaHashMap()
 
-for((k, v) <- j) s += ( k -> v)
+for ((k, v) <- j.asScala) s += (k -> v)
 
 println(s)
-
-
-


### PR DESCRIPTION
The original version has 2 problems:
* The `import java.util.{HashMap => JavaHashMap, Map => JavaMap}` is not used at all
* Got warning: object JavaConversions in package collection is deprecated (since 2.12.0): use JavaConverters